### PR TITLE
Fix tests broken by medic_attrs/1

### DIFF
--- a/test/med_hub/practices_test.exs
+++ b/test/med_hub/practices_test.exs
@@ -104,10 +104,9 @@ defmodule MedHub.PracticesTest do
     test "create_medic/1 with valid data creates a medic" do
       attrs = medic_attrs()
       assert {:ok, %Medic{} = medic} = Practices.create_medic(attrs)
-      assert medic.name == "some name"
-      assert medic.title == "some title"
-      assert medic.gender == attrs.gender
-      assert medic.specialty == "some specialty"
+
+      keys = Map.keys(attrs)
+      assert attrs == Map.take(medic, keys)
     end
 
     test "create_medic/1 with invalid data returns error changeset" do


### PR DESCRIPTION
Introducing `medic_attrs/1` broke the auto generated test.

I don't know how I missed this, but circleci should at least warn us of broken tests in the future.